### PR TITLE
Improved and cleaned code to create histograms

### DIFF
--- a/draw_NEUTRINO2022/draw_nue.C
+++ b/draw_NEUTRINO2022/draw_nue.C
@@ -23,52 +23,25 @@ void draw(TList * lout)
 
   const int *cols=style::GetColorArray();
 
-  TList* hists = new TList;
-
-  int iii = 0;
+  //create new arrays with selected colors for plot and muon central momenta for histograms and legend entries --> arrays need to be same size as lout !
+  const int cols_sel[9] = {cols[0],cols[1],cols[2],cols[5],cols[6],cols[8],cols[10],cols[11],cols[12]};
+  const float centPmu[9] = {0.57, 1.16, 1.80, 2.46, 3.12, 3.85, 4.60, 5.30, 6.00};
+  const TString percent = "%"; //needs to be created because single % will give error in Form()
 
   for(int ii=0; ii<lout->GetSize(); ii++){
     TH1F * hh = dynamic_cast<TH1F *> (lout->At(ii));
     style::ResetStyle(hh);
-
-    hists->Add(hh);
-
-    std::cout<<iii<<std::endl;
-
-    //    if ((ii == 1) or (ii == 3) or (ii == 5) or (ii == 7) or (ii == 0)) {
 
     //here set for each histogram
     hh->GetXaxis()->SetTitle("#it{E}_{#nu} (GeV)");
     hh->GetYaxis()->SetTitle("#it{#Phi}_{#nu_{e}}(#it{E}_{#nu}) (a.u.)");//Question: is it really event rates of interaction, or just flux?
     hh->GetXaxis()->SetRangeUser(0,8); //used 8 for nu_e and 8.5 for nu_mu
     hh->SetLineWidth(2);
-    // if (ii==7){
-    //   hh->SetLineColor(style::GetColor(cols[9]));
-    // }
-    // else {
-    hh->SetLineColor(style::GetColor(cols[iii]));
-    //}
-    hh->Draw(ii?"same":"");//use C for smooth curve, expected to work for high statistics
-    const TString tmp=hh->GetName();
-    //lg->AddEntry(hh, Form("abc %c", tmp[6]), "l");//Here you have to replace hh->GetName() by the actual identifier of the histogram
-
-    // }
-
-    iii = iii+1;
-    if ((iii==7) or (iii==3)){
-      iii = iii+1;
-    }
+    hh->SetLineColor(style::GetColor(cols_sel[lout->GetSize()-1-ii]));
+    hh->Draw(ii?"hist same":"hist");//use C for smooth curve, expected to work for high statistics
+    const TString tmp=Form("#it{p}_{#mu} = %.2f GeV/#it{c} #pm 16", centPmu[lout->GetSize()-1-ii]);
+    lg->AddEntry(hh, tmp+percent, "l");
   }
-
-  lg->AddEntry(hists->At(8),"#it{p}_{#mu} = 0.57 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(7),"#it{p}_{#mu} = 1.16 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(6),"#it{p}_{#mu} = 1.80 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(5),"#it{p}_{#mu} = 2.46 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(4),"#it{p}_{#mu} = 3.12 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(3),"#it{p}_{#mu} = 3.85 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(2),"#it{p}_{#mu} = 4.60 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(1),"#it{p}_{#mu} = 5.30 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(0),"#it{p}_{#mu} = 6.00 GeV/#it{c} #pm 16%", "l");
 
   lg->Draw();
   cc->Print("hnueE.png");

--- a/draw_NEUTRINO2022/draw_nue_norm.C
+++ b/draw_NEUTRINO2022/draw_nue_norm.C
@@ -23,65 +23,35 @@ void draw(TList * lout)
 
   const int *cols=style::GetColorArray();
 
-  TList* hists = new TList;
-
-  int iii = 0;
+  //create new arrays with selected colors for plot and muon central momenta for histograms and legend entries
+  const int cols_sel[9] = {cols[0],cols[1],cols[2],cols[5],cols[6],cols[8],cols[10],cols[11],cols[12]};
+  const float centPmu[9] = {0.57, 1.16, 1.80, 2.46, 3.12, 3.85, 4.60, 5.30, 6.00};
+  const TString percent = "%"; //needs to be created because single % will give error in Form()
 
   for(int ii=0; ii<lout->GetSize(); ii++){
     TH1F * hh = dynamic_cast<TH1F *> (lout->At(ii));
     style::ResetStyle(hh);
-
-    hists->Add(hh);
-
-    std::cout<<iii<<std::endl;
-
-    //    if ((ii == 1) or (ii == 3) or (ii == 5) or (ii == 7) or (ii == 0)) {
 
     //here set for each histogram
     hh->GetXaxis()->SetTitle("#it{E}_{#nu} (GeV)");
     hh->GetYaxis()->SetTitle("#it{#Phi}_{#nu_{e}}(#it{E}_{#nu}) (area normalised)");//Question: is it really event rates of interaction, or just flux?
     hh->GetXaxis()->SetRangeUser(0,6); //used 8 for nu_e and 8.5 for nu_mu
     hh->SetLineWidth(2);
-    // if (ii==7){
-    //   hh->SetLineColor(style::GetColor(cols[9]));
-    // }
-    // else {
-    if (iii==4){
-      iii = iii+1;
-    }
-    hh->SetLineColor(style::GetColor(cols[iii]));
-    //}
+    hh->SetLineColor(style::GetColor(cols_sel[ii]));
     hh->Draw(ii?"hist same":"hist");//use C for smooth curve, expected to work for high statistics
-    const TString tmp=hh->GetName();
-    //lg->AddEntry(hh, Form("abc %c", tmp[6]), "l");//Here you have to replace hh->GetName() by the actual identifier of the histogram
-
-    // }
-
-    iii = iii+1;
-    if ((iii==7) or (iii==3) or (iii==9)){
-      iii = iii+1;
-    }
+    const TString tmp=Form("#it{p}_{#mu} = %.2f GeV/#it{c} #pm 16", centPmu[ii]);
+    lg->AddEntry(hh, tmp+percent, "l");
   }
 
-  lg->AddEntry(hists->At(0),"#it{p}_{#mu} = 0.57 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(1),"#it{p}_{#mu} = 1.16 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(2),"#it{p}_{#mu} = 1.80 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(3),"#it{p}_{#mu} = 2.46 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(4),"#it{p}_{#mu} = 3.12 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(5),"#it{p}_{#mu} = 3.85 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(6),"#it{p}_{#mu} = 4.60 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(7),"#it{p}_{#mu} = 5.30 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(8),"#it{p}_{#mu} = 6.00 GeV/#it{c} #pm 16%", "l");
-
   lg->Draw();
-  cc->Print("hnueE_norm.png");
-  cc->Print("hnueE_norm.pdf");
-  cc->Print("hnueE_norm.eps");
+  cc->Print("hnueE_norm_ext.png");
+  cc->Print("hnueE_norm_ext.pdf");
+  cc->Print("hnueE_norm_ext.eps");
 }
 
 int main()
 {
-  TFile *fin = new TFile("hnueE_norm.root");//first, save your TCanvas by Print("test.root"), assuming your TCanvas has name c1
+  TFile *fin = new TFile("hnueE_norm_ext.root");//first, save your TCanvas by Print("test.root"), assuming your TCanvas has name c1
   TCanvas *c1 = (TCanvas*) fin->Get("c");
   if(!c1){
     printf("no c1\n"); fin->ls(); return 1;

--- a/draw_NEUTRINO2022/draw_nue_norm_sel.C
+++ b/draw_NEUTRINO2022/draw_nue_norm_sel.C
@@ -16,10 +16,14 @@ void draw(TList * lout)
   cc->SetRightMargin(0.03);//right margin as small as possible, not to cut away the x axis label
   cc->SetTopMargin(0.06);//top margin
 
-  TLegend * lg = new TLegend(0.60, 0.50, 0.93, 0.92);//adjust the legend box position here
+  TLegend * lg0 = new TLegend(0.66, 0.77, 0.94, 0.91);//adjust the legend box position here
+  TLegend * lg = new TLegend(0.78, 0.45, 0.98, 0.77);//adjust the legend box position here
 
+  style::ResetStyle(lg0, 0.2);
   style::ResetStyle(lg, 0.2);//width of the key
-  lg->SetHeader("nuSTORM #nu_{e} Preliminary","C");//need to change to #nu_{e} everywhere for #nu_{e}
+  lg0->SetHeader("nuSTORM Preliminary","C");//need to change to #nu_{e} everywhere for #nu_{e}
+  lg0->AddEntry((TObject*)0, "#nu_{e} flux (2206v2)", "");
+  lg0->AddEntry((TObject*)0, "#it{p}_{#mu} (GeV/#it{c}) #pm 16%", "");
 
   const int *cols=style::GetColorArray();
 
@@ -37,18 +41,24 @@ void draw(TList * lout)
       hh->GetXaxis()->SetTitle("#it{E}_{#nu} (GeV)");
       hh->GetYaxis()->SetTitle("#it{#Phi}_{#nu_{e}}(#it{E}_{#nu}) (area normalised)");//Question: is it really event rates of interaction, or just flux?
       hh->GetXaxis()->SetRangeUser(0,6); //used 8 for nu_e and 8.5 for nu_mu
+      // hh->GetYaxis()->SetRangeUser(0,3.8); //for non-log plot
+      hh->GetYaxis()->SetRangeUser(0.03,4.5); //for log plot
+      hh->GetYaxis()->SetTitleOffset(1.15); //for log plot
+      hh->GetYaxis()->SetLabelOffset(0.001); //for log plot
       hh->SetLineWidth(2);
       hh->SetLineColor(style::GetColor(cols_sel[ii]));
-      hh->Draw(ii?"hist same":"hist");//use C for smooth curve, expected to work for high statistics
-      const TString tmp=Form("#it{p}_{#mu} = %.2f GeV/#it{c} #pm 16", centPmu[ii]);
-      lg->AddEntry(hh, tmp+percent, "l");
+      hh->Draw(ii?"hist same":"hist");//use "hist C" for smooth curve, expected to work for high statistics
+      //const TString tmp=Form("#it{p}_{#mu} = %.2f GeV/#it{c} #pm 16", centPmu[ii]);
+      lg->AddEntry(hh, Form("%.2f", centPmu[ii]), "l");
     }
   }
 
+  lg0->Draw();
   lg->Draw();
-  cc->Print("hnueE_norm_sel_ext.png");
-  cc->Print("hnueE_norm_sel_ext.pdf");
-  cc->Print("hnueE_norm_sel_ext.eps");
+  cc->SetLogy(); //Use this to show y-axis in log
+  cc->Print("hnueE_norm_sel_ext_log.png");
+  cc->Print("hnueE_norm_sel_ext_log.pdf");
+  cc->Print("hnueE_norm_sel_ext_log.eps");
 }
 
 int main()

--- a/draw_NEUTRINO2022/draw_nue_norm_sel.C
+++ b/draw_NEUTRINO2022/draw_nue_norm_sel.C
@@ -23,65 +23,37 @@ void draw(TList * lout)
 
   const int *cols=style::GetColorArray();
 
-  TList* hists = new TList;
-
-  int iii = 0;
+  //create new arrays with selected colors for plot and muon central momenta for histograms and legend entries
+  const int cols_sel[9] = {cols[0],cols[1],cols[2],cols[5],cols[6],cols[8],cols[10],cols[11],cols[12]};
+  const float centPmu[9] = {0.57, 1.16, 1.80, 2.46, 3.12, 3.85, 4.60, 5.30, 6.00};
+  const TString percent = "%"; //needs to be created because single % will give error in Form()
 
   for(int ii=0; ii<lout->GetSize(); ii++){
     TH1F * hh = dynamic_cast<TH1F *> (lout->At(ii));
     style::ResetStyle(hh);
 
-    hists->Add(hh);
-
-    std::cout<<iii<<std::endl;
-
     if ((ii != 5) and (ii != 7)) {
-
       //here set for each histogram
       hh->GetXaxis()->SetTitle("#it{E}_{#nu} (GeV)");
       hh->GetYaxis()->SetTitle("#it{#Phi}_{#nu_{e}}(#it{E}_{#nu}) (area normalised)");//Question: is it really event rates of interaction, or just flux?
       hh->GetXaxis()->SetRangeUser(0,6); //used 8 for nu_e and 8.5 for nu_mu
       hh->SetLineWidth(2);
-      // if (ii==7){
-      //   hh->SetLineColor(style::GetColor(cols[9]));
-      // }
-      // else {
-      if (iii==4){
-        iii = iii+1;
-      }
-      hh->SetLineColor(style::GetColor(cols[iii]));
-      //}
+      hh->SetLineColor(style::GetColor(cols_sel[ii]));
       hh->Draw(ii?"hist same":"hist");//use C for smooth curve, expected to work for high statistics
-      const TString tmp=hh->GetName();
-      //lg->AddEntry(hh, Form("abc %c", tmp[6]), "l");//Here you have to replace hh->GetName() by the actual identifier of the histogram
-
-    }
-
-    iii = iii+1;
-    if ((iii==7) or (iii==3) or (iii==9)){
-      iii = iii+1;
+      const TString tmp=Form("#it{p}_{#mu} = %.2f GeV/#it{c} #pm 16", centPmu[ii]);
+      lg->AddEntry(hh, tmp+percent, "l");
     }
   }
 
-  lg->AddEntry(hists->At(0),"#it{p}_{#mu} = 0.57 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(1),"#it{p}_{#mu} = 1.16 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(2),"#it{p}_{#mu} = 1.80 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(3),"#it{p}_{#mu} = 2.46 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(4),"#it{p}_{#mu} = 3.12 GeV/#it{c} #pm 16%", "l");
-  // lg->AddEntry(hists->At(5),"#it{p}_{#mu} = 3.85 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(6),"#it{p}_{#mu} = 4.60 GeV/#it{c} #pm 16%", "l");
-  // lg->AddEntry(hists->At(7),"#it{p}_{#mu} = 5.30 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(8),"#it{p}_{#mu} = 6.00 GeV/#it{c} #pm 16%", "l");
-
   lg->Draw();
-  cc->Print("hnueE_norm_sel.png");
-  cc->Print("hnueE_norm_sel.pdf");
-  cc->Print("hnueE_norm_sel.eps");
+  cc->Print("hnueE_norm_sel_ext.png");
+  cc->Print("hnueE_norm_sel_ext.pdf");
+  cc->Print("hnueE_norm_sel_ext.eps");
 }
 
 int main()
 {
-  TFile *fin = new TFile("hnueE_norm.root");//first, save your TCanvas by Print("test.root"), assuming your TCanvas has name c1
+  TFile *fin = new TFile("hnueE_norm_ext.root");//first, save your TCanvas by Print("test.root"), assuming your TCanvas has name c1
   TCanvas *c1 = (TCanvas*) fin->Get("c");
   if(!c1){
     printf("no c1\n"); fin->ls(); return 1;

--- a/draw_NEUTRINO2022/draw_nue_sel.C
+++ b/draw_NEUTRINO2022/draw_nue_sel.C
@@ -23,52 +23,27 @@ void draw(TList * lout)
 
   const int *cols=style::GetColorArray();
 
-  TList* hists = new TList;
-
-  int iii = 0;
+  //create new arrays with selected colors for plot and muon central momenta for histograms and legend entries --> arrays need to be same size as lout !
+  const int cols_sel[9] = {cols[0],cols[1],cols[2],cols[5],cols[6],cols[8],cols[10],cols[11],cols[12]};
+  const float centPmu[9] = {0.57, 1.16, 1.80, 2.46, 3.12, 3.85, 4.60, 5.30, 6.00};
+  const TString percent = "%"; //needs to be created because single % will give error in Form()
 
   for(int ii=0; ii<lout->GetSize(); ii++){
     TH1F * hh = dynamic_cast<TH1F *> (lout->At(ii));
     style::ResetStyle(hh);
 
-    hists->Add(hh);
-
-    std::cout<<iii<<std::endl;
-
-    if ((ii == 1) or (ii == 3) or (ii == 5) or (ii == 7) or (ii == 0)) {
-
+    if ((ii != 1) and (ii != 3)) {
       //here set for each histogram
       hh->GetXaxis()->SetTitle("#it{E}_{#nu} (GeV)");
       hh->GetYaxis()->SetTitle("#it{#Phi}_{#nu_{e}}(#it{E}_{#nu}) (a.u.)");//Question: is it really event rates of interaction, or just flux?
       hh->GetXaxis()->SetRangeUser(0,8); //used 8 for nu_e and 8.5 for nu_mu
       hh->SetLineWidth(2);
-      // if (ii==7){
-      //   hh->SetLineColor(style::GetColor(cols[9]));
-      // }
-      // else {
-      hh->SetLineColor(style::GetColor(cols[iii]));
-      //}
-      hh->Draw(ii?"same":"");//use C for smooth curve, expected to work for high statistics
-      const TString tmp=hh->GetName();
-      //lg->AddEntry(hh, Form("abc %c", tmp[6]), "l");//Here you have to replace hh->GetName() by the actual identifier of the histogram
-
-    }
-
-    iii = iii+1;
-    if ((iii==7) or (iii==3)){
-      iii = iii+1;
+      hh->SetLineColor(style::GetColor(cols_sel[lout->GetSize()-1-ii]));
+      hh->Draw(ii?"hist same":"hist");//use C for smooth curve, expected to work for high statistics
+      const TString tmp=Form("#it{p}_{#mu} = %.2f GeV/#it{c} #pm 16", centPmu[lout->GetSize()-1-ii]);
+      lg->AddEntry(hh, tmp+percent, "l");
     }
   }
-
-  //lg->AddEntry(hists->At(8),"#it{p}_{#mu} = 0.57 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(7),"#it{p}_{#mu} = 1.16 GeV/#it{c} #pm 16%", "l");
-  //lg->AddEntry(hists->At(6),"#it{p}_{#mu} = 1.80 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(5),"#it{p}_{#mu} = 2.46 GeV/#it{c} #pm 16%", "l");
-  //lg->AddEntry(hists->At(4),"#it{p}_{#mu} = 3.12 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(3),"#it{p}_{#mu} = 3.85 GeV/#it{c} #pm 16%", "l");
-  //lg->AddEntry(hists->At(2),"#it{p}_{#mu} = 4.60 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(1),"#it{p}_{#mu} = 5.30 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(0),"#it{p}_{#mu} = 6.00 GeV/#it{c} #pm 16%", "l");
 
   lg->Draw();
   cc->Print("hnueE_sel.png");

--- a/draw_NEUTRINO2022/draw_numu.C
+++ b/draw_NEUTRINO2022/draw_numu.C
@@ -19,56 +19,29 @@ void draw(TList * lout)
   TLegend * lg = new TLegend(0.60, 0.40, 0.93, 0.92);//adjust the legend box position here
 
   style::ResetStyle(lg, 0.2);//width of the key
-  lg->SetHeader("nuSTORM #nu_{#mu} Preliminary","C");//need to change to #nu_{e} everywhere for #nu_{e}
+  lg->SetHeader("nuSTORM #bar{#nu}_{#mu} Preliminary","C");//need to change to #nu_{e} everywhere for #nu_{e}
 
   const int *cols=style::GetColorArray();
 
-  TList* hists = new TList;
-
-  int iii = 0;
+  //create new arrays with selected colors for plot and muon central momenta for histograms and legend entries --> arrays need to be same size as lout !
+  const int cols_sel[9] = {cols[0],cols[1],cols[2],cols[5],cols[6],cols[8],cols[10],cols[11],cols[12]};
+  const float centPmu[9] = {0.57, 1.16, 1.80, 2.46, 3.12, 3.85, 4.60, 5.30, 6.00};
+  const TString percent = "%"; //needs to be created because single % will give error in Form()
 
   for(int ii=0; ii<lout->GetSize(); ii++){
     TH1F * hh = dynamic_cast<TH1F *> (lout->At(ii));
     style::ResetStyle(hh);
 
-    hists->Add(hh);
-
-    std::cout<<iii<<std::endl;
-
-    //    if ((ii == 1) or (ii == 3) or (ii == 5) or (ii == 7) or (ii == 0)) {
-
     //here set for each histogram
     hh->GetXaxis()->SetTitle("#it{E}_{#nu} (GeV)");
-    hh->GetYaxis()->SetTitle("#it{#Phi}_{#nu_{#mu}}(#it{E}_{#nu}) (a.u.)");//Question: is it really event rates of interaction, or just flux?
+    hh->GetYaxis()->SetTitle("#it{#Phi}_{#bar{#nu}_{#mu}}(#it{E}_{#nu}) (a.u.)");//Question: is it really event rates of interaction, or just flux?
     hh->GetXaxis()->SetRangeUser(0,9); //used 8 for nu_e and 8.5 for nu_mu
     hh->SetLineWidth(2);
-    // if (ii==7){
-    //   hh->SetLineColor(style::GetColor(cols[9]));
-    // }
-    // else {
-    hh->SetLineColor(style::GetColor(cols[iii]));
-    //}
-    hh->Draw(ii?"same":"");//use C for smooth curve, expected to work for high statistics
-    const TString tmp=hh->GetName();
-    //lg->AddEntry(hh, Form("abc %c", tmp[6]), "l");//Here you have to replace hh->GetName() by the actual identifier of the histogram
-
-    // }
-
-    iii = iii+1;
-    if ((iii==7) or (iii==3)){
-      iii = iii+1;
-    }
+    hh->SetLineColor(style::GetColor(cols_sel[lout->GetSize()-1-ii]));
+    hh->Draw(ii?"hist same":"hist");//use C for smooth curve, expected to work for high statistics
+    const TString tmp=Form("#it{p}_{#mu} = %.2f GeV/#it{c} #pm 16", centPmu[lout->GetSize()-1-ii]);
+    lg->AddEntry(hh, tmp+percent, "l");
   }
-
-  lg->AddEntry(hists->At(8),"#it{p}_{#mu} = 0.57 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(7),"#it{p}_{#mu} = 1.16 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(6),"#it{p}_{#mu} = 1.80 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(5),"#it{p}_{#mu} = 2.46 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(4),"#it{p}_{#mu} = 3.12 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(3),"#it{p}_{#mu} = 3.85 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(2),"#it{p}_{#mu} = 4.60 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(1),"#it{p}_{#mu} = 5.30 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(0),"#it{p}_{#mu} = 6.00 GeV/#it{c} #pm 16%", "l");
 
   lg->Draw();
   cc->Print("hnumuE_full.png");

--- a/draw_NEUTRINO2022/draw_numu_norm.C
+++ b/draw_NEUTRINO2022/draw_numu_norm.C
@@ -19,69 +19,39 @@ void draw(TList * lout)
   TLegend * lg = new TLegend(0.60, 0.40, 0.93, 0.92);//adjust the legend box position here
 
   style::ResetStyle(lg, 0.2);//width of the key
-  lg->SetHeader("nuSTORM #nu_{#mu} Preliminary","C");//need to change to #nu_{e} everywhere for #nu_{e}
+  lg->SetHeader("nuSTORM #bar{#nu}_{#mu} Preliminary","C");//need to change to #nu_{e} everywhere for #nu_{e}
 
   const int *cols=style::GetColorArray();
 
-  TList* hists = new TList;
-
-  int iii = 0;
+  //create new arrays with selected colors for plot and muon central momenta for histograms and legend entries
+  const int cols_sel[9] = {cols[0],cols[1],cols[2],cols[5],cols[6],cols[8],cols[10],cols[11],cols[12]};
+  const float centPmu[9] = {0.57, 1.16, 1.80, 2.46, 3.12, 3.85, 4.60, 5.30, 6.00};
+  const TString percent = "%"; //needs to be created because single % will give error in Form()
 
   for(int ii=0; ii<lout->GetSize(); ii++){
     TH1F * hh = dynamic_cast<TH1F *> (lout->At(ii));
     style::ResetStyle(hh);
 
-    hists->Add(hh);
-
-    std::cout<<iii<<std::endl;
-
-    //    if ((ii == 1) or (ii == 3) or (ii == 5) or (ii == 7) or (ii == 0)) {
-
     //here set for each histogram
     hh->GetXaxis()->SetTitle("#it{E}_{#nu} (GeV)");
-    hh->GetYaxis()->SetTitle("#it{#Phi}_{#nu_{#mu}}(#it{E}_{#nu}) (area normalised)");//Question: is it really event rates of interaction, or just flux?
+    hh->GetYaxis()->SetTitle("#it{#Phi}_{#bar{#nu}_{#mu}}(#it{E}_{#nu}) (area normalised)");
     hh->GetXaxis()->SetRangeUser(0,6); //used 8 for nu_e and 8.5 for nu_mu
     hh->SetLineWidth(2);
-    // if (ii==7){
-    //   hh->SetLineColor(style::GetColor(cols[9]));
-    // }
-    // else {
-    if (iii==4){
-      iii = iii+1;
-    }
-    hh->SetLineColor(style::GetColor(cols[iii]));
-    //}
+    hh->SetLineColor(style::GetColor(cols_sel[ii]));
     hh->Draw(ii?"hist same":"hist");//use C for smooth curve, expected to work for high statistics
-    const TString tmp=hh->GetName();
-    //lg->AddEntry(hh, Form("abc %c", tmp[6]), "l");//Here you have to replace hh->GetName() by the actual identifier of the histogram
-
-    // }
-
-    iii = iii+1;
-    if ((iii==7) or (iii==3) or (iii==9)){
-      iii = iii+1;
-    }
+    const TString tmp=Form("#it{p}_{#mu} = %.2f GeV/#it{c} #pm 16", centPmu[ii]);
+    lg->AddEntry(hh, tmp+percent, "l");
   }
 
-  lg->AddEntry(hists->At(0),"#it{p}_{#mu} = 0.57 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(1),"#it{p}_{#mu} = 1.16 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(2),"#it{p}_{#mu} = 1.80 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(3),"#it{p}_{#mu} = 2.46 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(4),"#it{p}_{#mu} = 3.12 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(5),"#it{p}_{#mu} = 3.85 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(6),"#it{p}_{#mu} = 4.60 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(7),"#it{p}_{#mu} = 5.30 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(8),"#it{p}_{#mu} = 6.00 GeV/#it{c} #pm 16%", "l");
-
   lg->Draw();
-  cc->Print("hnumuE_norm.png");
-  cc->Print("hnumuE_norm.pdf");
-  cc->Print("hnumuE_norm.eps");
+  cc->Print("hnumuE_norm_ext.png");
+  cc->Print("hnumuE_norm_ext.pdf");
+  cc->Print("hnumuE_norm_ext.eps");
 }
 
 int main()
 {
-  TFile *fin = new TFile("hnumuE_norm.root");//first, save your TCanvas by Print("test.root"), assuming your TCanvas has name c1
+  TFile *fin = new TFile("hnumuE_norm_ext.root");//first, save your TCanvas by Print("test.root"), assuming your TCanvas has name c1
   TCanvas *c1 = (TCanvas*) fin->Get("c");
   if(!c1){
     printf("no c1\n"); fin->ls(); return 1;

--- a/draw_NEUTRINO2022/draw_numu_norm_sel.C
+++ b/draw_NEUTRINO2022/draw_numu_norm_sel.C
@@ -19,69 +19,42 @@ void draw(TList * lout)
   TLegend * lg = new TLegend(0.60, 0.50, 0.93, 0.92);//adjust the legend box position here
 
   style::ResetStyle(lg, 0.2);//width of the key
-  lg->SetHeader("nuSTORM #nu_{#mu} Preliminary","C");//need to change to #nu_{e} everywhere for #nu_{e}
+  lg->SetHeader("nuSTORM #bar{#nu}_{#mu} Preliminary","C");//need to change to #nu_{e} everywhere for #nu_{e}
 
   const int *cols=style::GetColorArray();
 
-  TList* hists = new TList;
-
-  int iii = 0;
+  //create new arrays with selected colors for plot and muon central momenta for histograms and legend entries
+  const int cols_sel[9] = {cols[0],cols[1],cols[2],cols[5],cols[6],cols[8],cols[10],cols[11],cols[12]};
+  const float centPmu[9] = {0.57, 1.16, 1.80, 2.46, 3.12, 3.85, 4.60, 5.30, 6.00};
+  const TString percent = "%"; //needs to be created because single % will give error in Form()
 
   for(int ii=0; ii<lout->GetSize(); ii++){
     TH1F * hh = dynamic_cast<TH1F *> (lout->At(ii));
     style::ResetStyle(hh);
 
-    hists->Add(hh);
-
-    std::cout<<iii<<std::endl;
-
+    //skip two energies to make plot more legible
     if ((ii != 5) and (ii != 7)) {
-
       //here set for each histogram
       hh->GetXaxis()->SetTitle("#it{E}_{#nu} (GeV)");
-      hh->GetYaxis()->SetTitle("#it{#Phi}_{#nu_{#mu}}(#it{E}_{#nu}) (area normalised)");//Question: is it really event rates of interaction, or just flux?
+      hh->GetYaxis()->SetTitle("#it{#Phi}_{#bar{#nu}_{#mu}}(#it{E}_{#nu}) (area normalised)");//Question: is it really event rates of interaction, or just flux?
       hh->GetXaxis()->SetRangeUser(0,6); //used 8 for nu_e and 8.5 for nu_mu
       hh->SetLineWidth(2);
-      // if (ii==7){
-      //   hh->SetLineColor(style::GetColor(cols[9]));
-      // }
-      // else {
-      if (iii==4){
-        iii = iii+1;
-      }
-      hh->SetLineColor(style::GetColor(cols[iii]));
-      //}
+      hh->SetLineColor(style::GetColor(cols_sel[ii]));
       hh->Draw(ii?"hist same":"hist");//use C for smooth curve, expected to work for high statistics
-      const TString tmp=hh->GetName();
-      //lg->AddEntry(hh, Form("abc %c", tmp[6]), "l");//Here you have to replace hh->GetName() by the actual identifier of the histogram
-
-    }
-
-    iii = iii+1;
-    if ((iii==7) or (iii==3) or (iii==9)){
-      iii = iii+1;
+      const TString tmp=Form("#it{p}_{#mu} = %.2f GeV/#it{c} #pm 16", centPmu[ii]);
+      lg->AddEntry(hh, tmp+percent, "l");
     }
   }
 
-  lg->AddEntry(hists->At(0),"#it{p}_{#mu} = 0.57 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(1),"#it{p}_{#mu} = 1.16 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(2),"#it{p}_{#mu} = 1.80 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(3),"#it{p}_{#mu} = 2.46 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(4),"#it{p}_{#mu} = 3.12 GeV/#it{c} #pm 16%", "l");
-  // lg->AddEntry(hists->At(5),"#it{p}_{#mu} = 3.85 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(6),"#it{p}_{#mu} = 4.60 GeV/#it{c} #pm 16%", "l");
-  // lg->AddEntry(hists->At(7),"#it{p}_{#mu} = 5.30 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(8),"#it{p}_{#mu} = 6.00 GeV/#it{c} #pm 16%", "l");
-
   lg->Draw();
-  cc->Print("hnumuE_norm_sel.png");
-  cc->Print("hnumuE_norm_sel.pdf");
-  cc->Print("hnumuE_norm_sel.eps");
+  cc->Print("hnumuE_norm_sel_ext.png");
+  cc->Print("hnumuE_norm_sel_ext.pdf");
+  cc->Print("hnumuE_norm_sel_ext.eps");
 }
 
 int main()
 {
-  TFile *fin = new TFile("hnumuE_norm.root");//first, save your TCanvas by Print("test.root"), assuming your TCanvas has name c1
+  TFile *fin = new TFile("hnumuE_norm_ext.root");//first, save your TCanvas by Print("test.root"), assuming your TCanvas has name c1
   TCanvas *c1 = (TCanvas*) fin->Get("c");
   if(!c1){
     printf("no c1\n"); fin->ls(); return 1;

--- a/draw_NEUTRINO2022/draw_numu_norm_sel.C
+++ b/draw_NEUTRINO2022/draw_numu_norm_sel.C
@@ -16,10 +16,14 @@ void draw(TList * lout)
   cc->SetRightMargin(0.03);//right margin as small as possible, not to cut away the x axis label
   cc->SetTopMargin(0.06);//top margin
 
-  TLegend * lg = new TLegend(0.60, 0.50, 0.93, 0.92);//adjust the legend box position here
+  TLegend * lg0 = new TLegend(0.66, 0.77, 0.94, 0.91);//adjust the legend box position here
+  TLegend * lg = new TLegend(0.78, 0.45, 0.98, 0.77);//adjust the legend box position here
 
+  style::ResetStyle(lg0, 0.2);//width of the key
   style::ResetStyle(lg, 0.2);//width of the key
-  lg->SetHeader("nuSTORM #bar{#nu}_{#mu} Preliminary","C");//need to change to #nu_{e} everywhere for #nu_{e}
+  lg0->SetHeader("nuSTORM Preliminary","C");//need to change to #nu_{e} everywhere for #nu_{e}
+  lg0->AddEntry((TObject*)0, "#bar{#nu}_{#mu} flux (2206v2)", "");
+  lg0->AddEntry((TObject*)0, "#it{p}_{#mu} (GeV/#it{c}) #pm 16%", "");
 
   const int *cols=style::GetColorArray();
 
@@ -36,17 +40,24 @@ void draw(TList * lout)
     if ((ii != 5) and (ii != 7)) {
       //here set for each histogram
       hh->GetXaxis()->SetTitle("#it{E}_{#nu} (GeV)");
-      hh->GetYaxis()->SetTitle("#it{#Phi}_{#bar{#nu}_{#mu}}(#it{E}_{#nu}) (area normalised)");//Question: is it really event rates of interaction, or just flux?
+      hh->GetYaxis()->SetTitle("#it{#Phi}_{#bar{#nu}_{#mu}}(#it{E}_{#nu}) (area normalised)");
       hh->GetXaxis()->SetRangeUser(0,6); //used 8 for nu_e and 8.5 for nu_mu
+      hh->GetYaxis()->SetRangeUser(0,3.8); //for non-log plot
+      //hh->GetYaxis()->SetRangeUser(0.03,4.5); //for log plot
+      //hh->GetYaxis()->SetTitleOffset(1.15); //for log plot
+      //hh->GetYaxis()->SetLabelOffset(0.001); //for log plot
       hh->SetLineWidth(2);
       hh->SetLineColor(style::GetColor(cols_sel[ii]));
-      hh->Draw(ii?"hist same":"hist");//use C for smooth curve, expected to work for high statistics
-      const TString tmp=Form("#it{p}_{#mu} = %.2f GeV/#it{c} #pm 16", centPmu[ii]);
-      lg->AddEntry(hh, tmp+percent, "l");
+      hh->Draw(ii?"hist same":"hist");//use "hist C" for smooth curve, expected to work for high statistics
+      //const TString tmp=Form("%.2f", centPmu[ii]);
+      lg->AddEntry(hh, Form("%.2f", centPmu[ii]), "l");
     }
   }
 
+  //pt->Draw();
+  lg0->Draw();
   lg->Draw();
+  //cc->SetLogy(); //Use this to show y-axis in log
   cc->Print("hnumuE_norm_sel_ext.png");
   cc->Print("hnumuE_norm_sel_ext.pdf");
   cc->Print("hnumuE_norm_sel_ext.eps");

--- a/draw_NEUTRINO2022/draw_numu_sel.C
+++ b/draw_NEUTRINO2022/draw_numu_sel.C
@@ -19,56 +19,32 @@ void draw(TList * lout)
   TLegend * lg = new TLegend(0.60, 0.60, 0.93, 0.92);//adjust the legend box position here
 
   style::ResetStyle(lg, 0.2);//width of the key
-  lg->SetHeader("nuSTORM #nu_{#mu} Preliminary","C");//need to change to #nu_{e} everywhere for #nu_{e}
+  lg->SetHeader("nuSTORM #bar{#nu}_{#mu} Preliminary","C");//need to change to #nu_{e} everywhere for #nu_{e}
 
   const int *cols=style::GetColorArray();
 
-  TList* hists = new TList;
-
-  int iii = 0;
+  //create new arrays with selected colors for plot and muon central momenta for histograms and legend entries --> arrays need to be same size as lout !
+  const int cols_sel[9] = {cols[0],cols[1],cols[2],cols[5],cols[6],cols[8],cols[10],cols[11],cols[12]};
+  const float centPmu[9] = {0.57, 1.16, 1.80, 2.46, 3.12, 3.85, 4.60, 5.30, 6.00};
+  const TString percent = "%"; //needs to be created because single % will give error in Form()
 
   for(int ii=0; ii<lout->GetSize(); ii++){
     TH1F * hh = dynamic_cast<TH1F *> (lout->At(ii));
     style::ResetStyle(hh);
 
-    hists->Add(hh);
-
-    std::cout<<iii<<std::endl;
-
-    if ((ii == 1) or (ii == 3) or (ii == 5) or (ii == 7) or (ii == 0)) {
-
+    //skip two energies to make plot more legible
+    if ((ii != 1) and (ii != 3)) {
       //here set for each histogram
       hh->GetXaxis()->SetTitle("#it{E}_{#nu} (GeV)");
-      hh->GetYaxis()->SetTitle("#it{#Phi}_{#nu_{#mu}}(#it{E}_{#nu}) (a.u.)");//Question: is it really event rates of interaction, or just flux?
+      hh->GetYaxis()->SetTitle("#it{#Phi}_{#bar{#nu}_{#mu}}(#it{E}_{#nu}) (a.u.)");//Question: is it really event rates of interaction, or just flux?
       hh->GetXaxis()->SetRangeUser(0,8.5); //used 8 for nu_e and 8.5 for nu_mu
       hh->SetLineWidth(2);
-      // if (ii==7){
-      //   hh->SetLineColor(style::GetColor(cols[9]));
-      // }
-      // else {
-      hh->SetLineColor(style::GetColor(cols[iii]));
-      //}
-      hh->Draw(ii?"same":"");//use C for smooth curve, expected to work for high statistics
-      const TString tmp=hh->GetName();
-      //lg->AddEntry(hh, Form("abc %c", tmp[6]), "l");//Here you have to replace hh->GetName() by the actual identifier of the histogram
-
-    }
-
-    iii = iii+1;
-    if ((iii==7) or (iii==3)){
-      iii = iii+1;
+      hh->SetLineColor(style::GetColor(cols_sel[lout->GetSize()-1-ii]));
+      hh->Draw(ii?"hist same":"hist");//use C for smooth curve, expected to work for high statistics
+      const TString tmp=Form("#it{p}_{#mu} = %.2f GeV/#it{c} #pm 16", centPmu[lout->GetSize()-1-ii]);
+      lg->AddEntry(hh, tmp+percent, "l");
     }
   }
-
-  //lg->AddEntry(hists->At(8),"#it{p}_{#mu} = 0.57 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(7),"#it{p}_{#mu} = 1.16 GeV/#it{c} #pm 16%", "l");
-  //lg->AddEntry(hists->At(6),"#it{p}_{#mu} = 1.80 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(5),"#it{p}_{#mu} = 2.46 GeV/#it{c} #pm 16%", "l");
-  //lg->AddEntry(hists->At(4),"#it{p}_{#mu} = 3.12 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(3),"#it{p}_{#mu} = 3.85 GeV/#it{c} #pm 16%", "l");
-  //lg->AddEntry(hists->At(2),"#it{p}_{#mu} = 4.60 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(1),"#it{p}_{#mu} = 5.30 GeV/#it{c} #pm 16%", "l");
-  lg->AddEntry(hists->At(0),"#it{p}_{#mu} = 6.00 GeV/#it{c} #pm 16%", "l");
 
   lg->Draw();
   cc->Print("hnumuE_sel.png");


### PR DESCRIPTION
The codes that were used to create the plots for Neutrino 2022 (draw_*_norm*.C) give identical outputs. The others were slightly adapted.